### PR TITLE
Added Slack announcement functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,15 +50,13 @@ end
 
 group :development, :test do
   gem 'rspec-rails'
-
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
-
-  # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
-
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :test do
+  gem 'factory_girl_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,11 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
@@ -340,6 +345,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   font-awesome-rails (~> 4.3.0.0)
   frosting
   github_api (~> 0.12.3)

--- a/app/assets/javascripts/announcement_monitor.coffee
+++ b/app/assets/javascripts/announcement_monitor.coffee
@@ -1,0 +1,21 @@
+class Statusboard.AnnouncementMonitor
+  constructor: ->
+    setInterval(@checkForAnnouncements, 1000)
+    @checkForAnnouncements()
+
+  displayAnnouncements: (data) ->
+    return unless data?
+
+    @show("#{data.user}: #{data.words}")
+
+  checkForAnnouncements: =>
+    $.get '/announcements.json', (data) =>
+      @displayAnnouncements(data)
+
+  show: (text) ->
+    $("#announcement").text(text)
+
+    $("#announcement").slideDown ->
+      setTimeout ->
+        $("#announcement").slideUp()
+      , 30000

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,8 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require_self
 //= require_tree .
 //= require bootstrap-sprockets
+
+window.Statusboard = {}

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -26,7 +26,9 @@ h3 {
 }
 
 marquee {
+  font-size: 3em;
   color: red;
+  font-weight: bold;
 }
 
 #twitter {

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,7 @@
+class AnnouncementsController < ApplicationController
+  def index
+    announcement = Announcement.unannounced.oldest_first.first
+    announcement.announced! if announcement
+    render json: announcement
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,15 @@
+class Announcement < ActiveRecord::Base
+  validates :words, :user, presence: true
+
+  def self.unannounced
+    where(announced_at: nil)
+  end
+
+  def self.oldest_first
+    order(:created_at)
+  end
+
+  def announced!
+    update_attribute(:announced_at, Time.now)
+  end
+end

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -5,6 +5,12 @@
 <!-- <h1 id="title">Status Board</h1>
 <h3 id="subtitle">Foraker's Current Status: Too cool for school</h3> -->
 
+<marquee id="announcement"  scrollamount=17> </marquee>
+
 <% @status_board.components.each do |component| %>
   <%= render component.partial, component: component %>
 <% end %>
+
+<script type="text/javascript">
+new Statusboard.AnnouncementMonitor();
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,60 +1,6 @@
 Rails.application.routes.draw do
   get 'static_pages/index'
+  root 'static_pages#index'
 
-  get 'static_pages/home'
-
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
-
-  # You can have the root of your site routed with "root"
-   root 'static_pages#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  resources :announcements, only: :index
 end

--- a/db/migrate/20150710165656_create_announcements.rb
+++ b/db/migrate/20150710165656_create_announcements.rb
@@ -1,0 +1,11 @@
+class CreateAnnouncements < ActiveRecord::Migration
+  def change
+    create_table :announcements do |t|
+      t.text :words
+      t.string :user
+      t.timestamp :announced_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20150710165656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "announcements", force: :cascade do |t|
+    t.text     "words"
+    t.string   "user"
+    t.datetime "announced_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
 
 end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :announcement do
+    words "The building is on fire"
+    user "Stirling"
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  describe '.unannounced' do
+    it 'returns unannounced announcements' do
+      included = FactoryGirl.create :announcement, announced_at: nil
+      excluded = FactoryGirl.create :announcement, announced_at: Time.now
+
+      expect(described_class.unannounced).to eq [included]
+    end
+  end
+
+  describe '.oldest_first' do
+    it 'returns the oldest announcement first' do
+      one = FactoryGirl.create :announcement, created_at: 2.days.ago
+      two = FactoryGirl.create :announcement
+
+      expect(described_class.oldest_first).to eq [one, two]
+    end
+  end
+end


### PR DESCRIPTION
Now users can make announcements to the status board over Slack. There are two commands:
- statusboard marquee <message>
  - This will only display a scrolling marquee of text at the top of the screen
- statusboard announce <message>
  - In addition to the marquee, this will make an @channel announcement in #general

![](http://i.imgur.com/4aGwS.gif)
