### PR TITLE
Slack bot now has its own task [#99086890]

### DIFF
--- a/app/models/slack_bot.rb
+++ b/app/models/slack_bot.rb
@@ -39,10 +39,7 @@ class SlackBot
         end
       end
 
-    Thread.new do
       client.start
-    end
-
   end
 
   private

--- a/app/models/status_board.rb
+++ b/app/models/status_board.rb
@@ -1,8 +1,4 @@
 class StatusBoard
-  def initialize
-    start_slack_bot
-  end
-
   def components
     [
       twitter_component,
@@ -32,9 +28,5 @@ class StatusBoard
 
   def parser_component
     @parser_component ||= UrlParser.new
-  end
-
-  def start_slack_bot
-    SlackBot.new
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :application, 'Statusboard'
 set :repo_url, 'git@github.com:foraker/statusboard.git'
 
 # Default branch is :master
-# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, '/var/www/my_app_name'

--- a/lib/tasks/slackbot.rake
+++ b/lib/tasks/slackbot.rake
@@ -1,0 +1,25 @@
+namespace :slackbot do
+
+  path = Rails.root.join('tmp/pids/slackbot.pid').to_s
+
+  task start: :environment do
+    unless File.exist?(path)
+      fork do
+        File.write(path, Process.pid)
+        SlackBot.new
+      end
+    else
+      puts "Only one instance at a time!"
+    end
+  end
+
+  task stop: :environment do
+    if File.exist?(path)
+      pid = File.read(path)
+      File.delete(path)
+      Process.kill("SIGHUP", pid.to_i)
+    else
+      puts "There is no instance of Slack Bot running"
+    end
+  end
+end

--- a/scratch/deploy.rb
+++ b/scratch/deploy.rb
@@ -1,0 +1,12 @@
+namespace :deploy do
+
+  after :restart, :clear_cache do
+    on roles(:web), in: :groups, limit: 3, wait: 10 do
+      # Here we can do anything such as:
+      # within release_path do
+      #   execute :rake, 'cache:clear'
+      # end
+    end
+  end
+
+end


### PR DESCRIPTION
The StatusBoard Bot can now be started using:

```
rake slackbot:start
```

and ended using:

```
rake slackbot:stop
```

These will run as cron jobs at the start of the day and the end of the day.
Contains some protection to prevent creating multiple instances of Slack bot.

![](http://i.imgur.com/9OdiNCl.gif)
