### PR TITLE
Add ability to load carousel page from URL

### DIFF
--- a/app/assets/javascripts/load_carousel.coffee
+++ b/app/assets/javascripts/load_carousel.coffee
@@ -1,0 +1,11 @@
+$ ->
+  @pageNo = switch window.location.hash.substr(1)
+    when 'recent'              then 0
+    when 'open'                then 1
+    when 'summary'             then 2
+    when 'twitter', 'weather'  then 3
+    when 'pull', 'pulls', 'pr' then 4
+    when 'analytics'           then 5
+    else                       parseInt(window.location.hash.substr(1))-1
+
+  if @pageNo > 0 then $('#carousel').carousel @pageNo


### PR DESCRIPTION
lets users access a specific page of the StatusBoard through the URL

for example, the following URLs will take you straight to the Pull Request page: 
http://status.foraker.com#5
http://status.foraker.com#pulls
http://status.foraker.com#pr

there's probably a better coffee way to do this

![](http://stream1.gifsoup.com/view3/1544135/4-pug-head-tilt-o.gif)
