### PR TITLE
Add padding to project names, change graph colors

### DIFF
--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -436,6 +436,7 @@ h3 {
 
   .story-name {
     padding-left: 50px;
+    padding-right: 50px;
     text-align: left;
     width: 60%;
     a {

--- a/app/models/pages/components/website_stats_component.rb
+++ b/app/models/pages/components/website_stats_component.rb
@@ -11,10 +11,10 @@ module Pages
       end
 
       class Chart
-        def initialize(options)
+        def initialize(options, config_path = Rails.root.join('config/graph_metrics.yml'))
           self.days    = options.fetch(:days)
           self.slice   = options.fetch(:slice)
-          self.metrics = options.fetch(:metrics, ['visitors', 'pageviews', 'sessions'])
+          self.metrics = YAML.load_file(config_path).map { |config| OpenStruct.new(config) }
         end
 
         def to_json
@@ -35,7 +35,7 @@ module Pages
 
         def series
           metrics.map do |metric|
-            Metric.new(metric, slice, nodes).as_json
+            Metric.new(metric.name, slice, nodes, metric.color).as_json
           end
         end
 
@@ -53,11 +53,12 @@ module Pages
           "Past #{days} Days"
         end
 
-        class Metric < Struct.new(:metric, :slice, :nodes)
+        class Metric < Struct.new(:metric, :slice, :nodes, :color)
           def as_json
             {
               name: name,
-              data: data
+              data: data,
+              color: color
             }
           end
 

--- a/config/graph_metrics.yml
+++ b/config/graph_metrics.yml
@@ -1,0 +1,9 @@
+-
+  name: "pageviews"
+  color: "#CEF13B"
+-
+  name: "sessions"
+  color: "#95CBB3"
+-
+  name: "visitors"
+  color: "#41B2F6"


### PR DESCRIPTION
This one is tough because the graph series colors have to be declared in js. The Metric class had been constructed perfectly so it didn't care about what actual metrics went through it or how many - now it has to know to add the 'color' attribute. 

Let me know if you guys can think of a better solution (maybe when passing in the names of the metrics also pass in the colors? Change array to hash, key is name, value is color?)

![](http://i.imgur.com/uhBJM.jpg)
